### PR TITLE
Fix stack capping/truncating on SBCL

### DIFF
--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -80,6 +80,14 @@
 (defun restarts ()
   (mapcar #'make-restart (compute-restarts)))
 
+(defun stack-capper (function)
+  (declare (optimize (debug 3)))
+  (funcall function))
+
+(defun stack-truncator (function)
+  (declare (optimize (debug 3)))
+  (funcall function))
+
 (defmacro with-truncated-stack (() &body body)
   `(stack-truncator (sb-int:named-lambda with-truncated-stack-lambda () ,@body)))
 


### PR DESCRIPTION
The stack truncation/capping is currently broken on SBCL when dissect is compiled with a `debug` quality less than three:

![before](https://i.imgur.com/JxQJ9Pk.png)

The problem is that SBCL performs last call optimization and throws away the stack frame of `stack-truncator` and `stack-capper`, but we need them to stay on the stack so we can find them later in `chop-stack`.  See the commit message for more info.

With this change, things work properly:

![after](https://i.imgur.com/hq0boIx.png)
