### PR TITLE
Fixed an error occured on CCL in present-object displaying a call with UnknownArguments.

### DIFF
--- a/interface.lisp
+++ b/interface.lisp
@@ -108,12 +108,19 @@
 
 (defmethod present-object ((call call) stream)
   (let ((*print-pretty* NIL)
-        (*print-readably* NIL))
-    (format stream "~d: ~:[~s ~s~;(~s~{ ~a~})~]"
-            (pos call) (listp (args call)) (call call)
-            (loop for arg in (args call)
-                  collect (or (ignore-errors (princ-to-string arg))
-                              "<error printing arg>")))))
+        (*print-readably* NIL)
+        (args (args call)))
+    (format stream "~d: ~:[(~s ~s)~;(~s~{ ~a~})~]"
+            (pos call)
+            ;; If args is a list then they will be listed
+            ;; separated by spaces.
+            (listp args)
+            (call call)
+            (if (listp args)
+                (loop for arg in args
+                      collect (or (ignore-errors (princ-to-string arg))
+                                  "<error printing arg>"))
+                args))))
 
 (defclass environment ()
   ((condition :initarg :condition :accessor environment-condition)


### PR DESCRIPTION
This error was a CCL specific, I encounter it using Rove unittest, which uses
dissect framework to print tracebacks of catched signals. When you call
a function with wrong number of arguments, CCL generates a stacktrace where some
call has an object of type DISSECT:UNKNOWN-ARGUMENTS, and present-object fails to
print the arguments for such call, because think that arguments should be a list.

Here is example of the stack trace, produced by fixed version of Dissect. Pay attention to the stack frame number 7:

```
   TOO-MANY-ARGUMENTS: Too many arguments in call to #<Compiled-function FOO2 #x3020020512AF>:
   3 arguments provided, at most 2 accepted.
     (EQUAL #1=(FOO2 1 2 3) #2=(LIST 1 2 3))
         #1# = #:INTERRUPT-WITH-ERROR
         #2# = (1 2 3)

     0: ((:INTERNAL #:MAIN10241 #:MAIN10231 #:MAIN10232 TEST-SOME-ERROR-SIGNALED) Too many arguments in call to #<Compiled-fu\
nction FOO2 #x3020020512AF>:
     3 arguments provided, at most 2 accepted. )
     1: (SIGNAL Too many arguments in call to #<Compiled-function FOO2 #x3020020512AF>:
     3 arguments provided, at most 2 accepted. )
     2: (CCL::%ERROR Too many arguments in call to #<Compiled-function FOO2 #x3020020512AF>:
     3 arguments provided, at most 2 accepted.  (NARGS 3 FN #<Compiled-function FOO2 #x3020020512AF>) 75524258)
     3: ((:INTERNAL CCL::%XERR-DISP))
     4: (CCL::FUNCALL-WITH-ERROR-REENTRY-DETECTION #<BOGUS object @ #x2415657F>)
     5: (CCL::%XERR-DISP 15393165019856)
     6: (CCL::%PASCAL-FUNCTIONS% 2 15393165019856)
     7: (NIL #<Unknown Arguments>)
     8: (FOO2 1 2 3)
     9: ((:INTERNAL ROVE/CORE/ASSERTION::MAIN #:MAIN10241 #:MAIN10231 #:MAIN10232 TEST-SOME-ERROR-SIGNALED))
     10: ((:INTERNAL #:MAIN10241 #:MAIN10231 #:MAIN10232 TEST-SOME-ERROR-SIGNALED))
     11: ((:INTERNAL #:MAIN10232 TEST-SOME-ERROR-SIGNALED))
     12: ((:INTERNAL #:MAIN10011 RUN-TEST))
     13: (RUN-TEST TEST-SOME-ERROR-SIGNALED STYLE SPEC)
     14: (CCL::CALL-CHECK-REGS RUN-TEST TEST-SOME-ERROR-SIGNALED)
```