### PR TITLE
Add Clasp support

### DIFF
--- a/backend/clasp.lisp
+++ b/backend/clasp.lisp
@@ -1,0 +1,39 @@
+(in-package #:org.tymoonnext.dissect)
+
+(defun stack ()
+  (let ((stack nil))
+    (clasp-debug:map-indexed-backtrace
+     (lambda (frame index)
+       (let ((csl (clasp-debug:frame-function-source-position frame)))
+         (push (make-instance 'call
+                 :pos index
+                 :call (or (clasp-debug:frame-function frame)
+                           (clasp-debug:frame-function-name frame))
+                 :args (clasp-debug:frame-arguments frame)
+                 :form (clasp-debug:frame-function-form frame)
+                 :file (and csl (clasp-debug:code-source-line-pathname csl))
+                 :line (and csl (clasp-debug:code-source-line-line-number csl)))
+               stack))))
+    (nreverse stack)))
+
+(defclass clasp-restart (restart)
+  ((conditions :initarg :conditions :accessor conditions)))
+
+(defun make-restart (restart)
+  (make-instance 'clasp-restart
+    :name (restart-name restart)
+    :report (write-to-string restart :escape nil :readably nil)
+    :restart (ext:restart-function restart)
+    :object restart
+    :interactive (ext:restart-interactive-function restart)
+    :test (ext:restart-test-function restart)
+    :conditions (ext:restart-associated-conditions restart)))
+
+(defun restarts ()
+  (mapcar #'make-restart (compute-restarts)))
+
+(defmacro with-capped-stack (&body body)
+  `(clasp-debug:with-capped-stack () ,@body))
+
+(defmacro with-truncated-stack (&body body)
+  `(clasp-debug:with-truncated-stack () ,@body))

--- a/backend/clasp.lisp
+++ b/backend/clasp.lisp
@@ -1,3 +1,8 @@
+#|
+ This file is part of Dissect
+ Author: Bike <aeshtaer@gmail.com>
+|#
+
 (in-package #:org.tymoonnext.dissect)
 
 (defun stack ()

--- a/dissect.asd
+++ b/dissect.asd
@@ -23,6 +23,7 @@
                 (#+abcl (:file "abcl")
                  #+allegro (:file "allegro")
                  #+ccl (:file "ccl")
+                 #+clasp (:file "clasp")
                  #+clisp (:file "clisp")
                  #+ecl (:file "ecl")
                  #+sbcl (:file "sbcl")))


### PR DESCRIPTION
Various minor concerns:

- dunno about copyright
- dynamic-extent concerns we already discussed
- I didn't do the thing that reads the definition from from the file if available
- I assumed that "if available" meant that the various frame readers should return `nil` if there's no good information
- function names may be things like strings (for C++ functions) or non-fbound names (like `(lambda (x))` or `(flet foo)`)
- I don't know what the `pos` of frames is for, so here it'll be the position in the actual call stack, which will often differ from the frame's position in the list returned by `stack` due to hidden system frames
- there don't seem to be readers for information like the source info of the call (rather than the function being called)