### PR TITLE
Minor fix: Remove some compiler warnings.

### DIFF
--- a/backend/abcl.lisp
+++ b/backend/abcl.lisp
@@ -130,11 +130,12 @@
      :args args
      :frame frame)))
 
-(defun stack ()
-  (chop-stack
-   (loop for frame in (cddr (sys:backtrace))
-         for i from 0
-         collect (make-call i frame))))
+(setf (fdefinition 'stack)
+      (lambda ()
+        (chop-stack
+         (loop for frame in (cddr (sys:backtrace))
+               for i from 0
+               collect (make-call i frame)))))
 
 (defclass abcl-restart (restart)
   ((interactive :initarg :interactive :accessor interactive)
@@ -155,5 +156,6 @@
    :test (system::restart-test-function restart)
    :object restart))
 
-(defun restarts ()
-  (mapcar #'make-restart (compute-restarts)))
+(setf (fdefinition 'restarts)
+      (lambda ()
+        (mapcar #'make-restart (compute-restarts))))

--- a/backend/allegro.lisp
+++ b/backend/allegro.lisp
@@ -45,13 +45,14 @@
                (return (next-frame frame)))
           finally (return top-frame))))
 
-(defun stack ()
-  (chop-stack
-   (loop for frame = (next-frame (next-frame (top-frame)))
-         then (next-frame frame)
-         for i from 0
-         while frame
-         collect (make-call i frame))))
+(setf (fdefinition 'stack)
+      (lambda ()
+        (chop-stack
+         (loop for frame = (next-frame (next-frame (top-frame)))
+                 then (next-frame frame)
+               for i from 0
+               while frame
+               collect (make-call i frame)))))
 
 (defclass acl-restart (restart)
   ())
@@ -71,5 +72,6 @@
    :test (excl::restart-test-function restart)
    :object restart))
 
-(defun restarts ()
-  (mapcar #'make-restart (compute-restarts)))
+(setf (fdefinition 'restarts)
+      (lambda ()
+        (mapcar #'make-restart (compute-restarts))))

--- a/backend/ccl.lisp
+++ b/backend/ccl.lisp
@@ -39,15 +39,16 @@
              (translate-logical-pathname (ccl:source-note-filename source-note)))
      :source-note source-note)))
 
-(defun stack ()
-  (let ((i 0)
-        (stack ()))
-    (ccl:map-call-frames
-     #'(lambda (pointer context)
-         (push (make-call i pointer context) stack)
-         (incf i))
-     :start-frame-number 1)
-    (chop-stack (nreverse stack))))
+(setf (fdefinition 'stack)
+      (lambda ()
+        (let ((i 0)
+              (stack ()))
+          (ccl:map-call-frames
+           #'(lambda (pointer context)
+               (push (make-call i pointer context) stack)
+               (incf i))
+           :start-frame-number 1)
+          (chop-stack (nreverse stack)))))
 
 (defclass ccl-restart (restart)
   ())
@@ -67,5 +68,7 @@
    :test (ccl::%restart-test restart)
    :object restart))
 
-(defun restarts ()
-  (mapcar #'make-restart (compute-restarts)))
+
+(setf (fdefinition 'restarts)
+      (lambda ()
+        (mapcar #'make-restart (compute-restarts))))

--- a/backend/clasp.lisp
+++ b/backend/clasp.lisp
@@ -5,37 +5,40 @@
 
 (in-package #:org.tymoonnext.dissect)
 
-(defun stack ()
-  (let ((stack nil))
-    (clasp-debug:map-indexed-backtrace
-     (lambda (frame index)
-       (let ((csl (clasp-debug:frame-function-source-position frame)))
-         (push (make-instance 'call
-                 :pos index
-                 :call (or (clasp-debug:frame-function-name frame)
-                           (clasp-debug:frame-function frame))
-                 :args (clasp-debug:frame-arguments frame)
-                 :form (clasp-debug:frame-function-form frame)
-                 :file (and csl (clasp-debug:code-source-line-pathname csl))
-                 :line (and csl (clasp-debug:code-source-line-line-number csl)))
-               stack))))
-    (nreverse stack)))
+(setf (fdefinition 'stack)
+      (lambda ()
+        (let ((stack nil))
+          (clasp-debug:map-indexed-backtrace
+           (lambda (frame index)
+             (let ((csl (clasp-debug:frame-function-source-position frame)))
+               (push (make-instance 'call
+                                    :pos index
+                                    :call (or (clasp-debug:frame-function-name frame)
+                                              (clasp-debug:frame-function frame))
+                                    :args (clasp-debug:frame-arguments frame)
+                                    :form (clasp-debug:frame-function-form frame)
+                                    :file (and csl (clasp-debug:code-source-line-pathname csl))
+                                    :line (and csl (clasp-debug:code-source-line-line-number csl)))
+                     stack))))
+          (nreverse stack))))
 
 (defclass clasp-restart (restart)
   ((conditions :initarg :conditions :accessor conditions)))
 
 (defun make-restart (restart)
   (make-instance 'clasp-restart
-    :name (restart-name restart)
-    :report (write-to-string restart :escape nil :readably nil)
-    :restart (ext:restart-function restart)
-    :object restart
-    :interactive (ext:restart-interactive-function restart)
-    :test (ext:restart-test-function restart)
-    :conditions (ext:restart-associated-conditions restart)))
+                 :name (restart-name restart)
+                 :report (write-to-string restart :escape nil :readably nil)
+                 :restart (ext:restart-function restart)
+                 :object restart
+                 :interactive (ext:restart-interactive-function restart)
+                 :test (ext:restart-test-function restart)
+                 :conditions (ext:restart-associated-conditions restart)))
 
-(defun restarts ()
-  (mapcar #'make-restart (compute-restarts)))
+
+(setf (fdefinition 'restarts)
+      (lambda ()
+        (mapcar #'make-restart (compute-restarts))))
 
 (defmacro with-capped-stack (&body body)
   `(clasp-debug:with-capped-stack () ,@body))

--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -214,16 +214,17 @@
        :file file
        :spec spec))))
 
-(defun stack ()
-  (chop-stack
-   (let ((mode 2 #|all-stack-elements|#))
-     (loop with i = -1
-           for last = NIL then frame
-           for frame = (sys::the-frame)
-           then (sys::frame-up 1 frame mode)
-           until (eq frame last)
-           unless (unneeded-frame-p frame)
-           collect (make-call (incf i) frame)))))
+(setf (fdefinition 'stack)
+      (lambda ()
+        (chop-stack
+         (let ((mode 2 #|all-stack-elements|#))
+           (loop with i = -1
+                 for last = NIL then frame
+                 for frame = (sys::the-frame)
+                   then (sys::frame-up 1 frame mode)
+                 until (eq frame last)
+                 unless (unneeded-frame-p frame)
+                   collect (make-call (incf i) frame))))))
 
 ;;;;;
 ;; Restarts
@@ -246,5 +247,6 @@
    :interactive (system::restart-interactive restart)
    :test (system::restart-test restart)))
 
-(defun restarts ()
-  (mapcar #'make-restart (compute-restarts)))
+(setf (fdefinition 'restarts)
+      (lambda ()
+        (mapcar #'make-restart (compute-restarts))))

--- a/backend/ecl.lisp
+++ b/backend/ecl.lisp
@@ -46,14 +46,15 @@
      :file (when file (translate-logical-pathname file))
      :file-pos position)))
 
-(defun stack ()
-  (chop-stack
-   (loop for ihs downfrom (1- (system::ihs-top)) above 0
-         for i from 0
-         collect (make-call
-                  i
-                  (system::ihs-fun ihs)
-                  (system::ihs-env ihs)))))
+(setf (fdefinition 'stack)
+      (lambda ()
+        (chop-stack
+         (loop for ihs downfrom (1- (system::ihs-top)) above 0
+               for i from 0
+               collect (make-call
+                        i
+                        (system::ihs-fun ihs)
+                        (system::ihs-env ihs))))))
 
 (defclass ecl-restart (restart)
   ())
@@ -73,5 +74,6 @@
    :interactive (system::restart-interactive-function restart)
    :test (system::restart-test-function restart)))
 
-(defun restarts ()
-  (mapcar #'make-restart (compute-restarts)))
+(setf (fdefinition 'restarts)
+      (lambda ()
+        (mapcar #'make-restart (compute-restarts))))


### PR DESCRIPTION
For the implementation backends, use `#'(SETF FDEFINITION)` and `#'(SETF MACRO-FUNCTION)`

This removes compiler warnings on implementations that warn on the redefinition of a function (or
macro-function).