### PR TITLE
Add `&optional` condition argument to `dissect:restarts`.

### DIFF
--- a/backend/abcl.lisp
+++ b/backend/abcl.lisp
@@ -157,5 +157,5 @@
    :object restart))
 
 (setf (fdefinition 'restarts)
-      (lambda ()
-        (mapcar #'make-restart (compute-restarts))))
+      (lambda (&optional condition)
+        (mapcar #'make-restart (compute-restarts condition))))

--- a/backend/allegro.lisp
+++ b/backend/allegro.lisp
@@ -73,5 +73,5 @@
    :object restart))
 
 (setf (fdefinition 'restarts)
-      (lambda ()
-        (mapcar #'make-restart (compute-restarts))))
+      (lambda (&optional condition)
+        (mapcar #'make-restart (compute-restarts condition))))

--- a/backend/ccl.lisp
+++ b/backend/ccl.lisp
@@ -70,5 +70,5 @@
 
 
 (setf (fdefinition 'restarts)
-      (lambda ()
-        (mapcar #'make-restart (compute-restarts))))
+      (lambda (&optional condition)
+        (mapcar #'make-restart (compute-restarts condition))))

--- a/backend/clasp.lisp
+++ b/backend/clasp.lisp
@@ -37,8 +37,8 @@
 
 
 (setf (fdefinition 'restarts)
-      (lambda ()
-        (mapcar #'make-restart (compute-restarts))))
+      (lambda (&optional condition)
+        (mapcar #'make-restart (compute-restarts condition))))
 
 (defmacro with-capped-stack (&body body)
   `(clasp-debug:with-capped-stack () ,@body))

--- a/backend/clisp.lisp
+++ b/backend/clisp.lisp
@@ -248,5 +248,5 @@
    :test (system::restart-test restart)))
 
 (setf (fdefinition 'restarts)
-      (lambda ()
-        (mapcar #'make-restart (compute-restarts))))
+      (lambda (&optional condition)
+        (mapcar #'make-restart (compute-restarts condition))))

--- a/backend/ecl.lisp
+++ b/backend/ecl.lisp
@@ -75,5 +75,5 @@
    :test (system::restart-test-function restart)))
 
 (setf (fdefinition 'restarts)
-      (lambda ()
-        (mapcar #'make-restart (compute-restarts))))
+      (lambda (&optional condition)
+        (mapcar #'make-restart (compute-restarts condition))))

--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -80,8 +80,8 @@
    :conditions (sb-kernel:restart-associated-conditions restart)))
 
 (setf (fdefinition 'restarts)
-      (lambda ()
-        (mapcar #'make-restart (compute-restarts))))
+      (lambda (&optional condition)
+        (mapcar #'make-restart (compute-restarts condition))))
 
 (setf (fdefinition 'stack-capper)
       (lambda (function)

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -28,6 +28,8 @@ See WITH-CAPPED-STACK")
   (function restarts
    "Returns a list of RESTART objects describing the currently available restarts.
 
+If CONDITION is provided, only return restarts associated with this condition.
+
 Returns an empty list on unsupported platforms.
 
 See RESTART")

--- a/interface.lisp
+++ b/interface.lisp
@@ -12,7 +12,7 @@
 
 (declaim (ftype (function (&optional (or null condition)) list) restarts)
          (notinline restarts))
-(defun restarts ())
+(defun restarts (&optional condition))
 
 (declaim (notinline stack-truncator))
 (defun stack-truncator (function)

--- a/interface.lisp
+++ b/interface.lisp
@@ -6,10 +6,12 @@
 
 (in-package #:org.tymoonnext.dissect)
 
-(declaim (ftype (function () list) stack restarts)
-         (notinline stack restarts))
+(declaim (ftype (function () list) stack)
+         (notinline stack))
 (defun stack ())
 
+(declaim (ftype (function (&optional (or null condition)) list) restarts)
+         (notinline restarts))
 (defun restarts ())
 
 (declaim (notinline stack-truncator))


### PR DESCRIPTION
This adds a `condition` argument to `restarts` so that the listing of restarts can be narrowed/expanded to a specific condition. It's consistent with the way (underlying) `compute-restarts` works. And it's a useful one, too. In particular, it brings better restart inspection for the debugger I'm currently working on, allowing to display condition-specific restarts in a much prettier yet portable way.

I'm thinking of doing the same for `dissect:stack`, but it seems much more complicated than `dissect:restarts` :D

@Shinmera, thanks for this library, by the way :black_heart: 