### PR TITLE
Spotty support for locals.

### DIFF
--- a/backend/allegro.lisp
+++ b/backend/allegro.lisp
@@ -26,7 +26,11 @@
    :pos i
    :call (xref::object-to-function-name (debugger:frame-function frame))
    :args (loop for i from 0 below (debugger:frame-number-vars frame)
-               collect (debugger:frame-var-value frame i))
+               unless (eq :local (debugger:frame-var-type frame i))
+                 collect (debugger:frame-var-value frame i))
+   :locals (loop for i from 0 below (debugger:frame-number-vars frame)
+                 collect (cons (debugger:frame-var-name frame i)
+                               (debugger:frame-var-value frame i)))
    :file (fspec-definition-location (debugger:frame-function frame))
    :line NIL))
 

--- a/backend/ccl.lisp
+++ b/backend/ccl.lisp
@@ -29,12 +29,15 @@
   (let* ((function (ccl:frame-function pointer context))
          (source-note (ccl:function-source-note function))
          (args (ccl:frame-supplied-arguments
-                pointer context :unknown-marker (make-instance 'unavailable-argument))))
+                pointer context :unknown-marker (make-instance 'unavailable-argument)))
+         (args (if (listp args) args (make-instance 'unknown-arguments))))
     (make-instance
      'ccl-call
      :pos i
      :call (or (ccl:function-name function) function)
-     :args (if (listp args) args (make-instance 'unknown-arguments))
+     :args args
+     :locals (loop for (name . value) in (ccl:frame-named-variables pointer context)
+                   collect (cons name value))
      :file (when (ccl:source-note-filename source-note)
              (translate-logical-pathname (ccl:source-note-filename source-note)))
      :source-note source-note)))

--- a/backend/clasp.lisp
+++ b/backend/clasp.lisp
@@ -16,6 +16,7 @@
                                     :call (or (clasp-debug:frame-function-name frame)
                                               (clasp-debug:frame-function frame))
                                     :args (clasp-debug:frame-arguments frame)
+                                    :locals (clasp-debug:frame-locals frame)
                                     :form (clasp-debug:frame-function-form frame)
                                     :file (and csl (clasp-debug:code-source-line-pathname csl))
                                     :line (and csl (clasp-debug:code-source-line-line-number csl)))

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -178,6 +178,13 @@ See UNKNOWN-ARGUMENTS
 See UNAVAILABLE-ARGUMENT
 See CALL")
   
+  (function locals
+            "Returns a dotted alist of locals bound in the frame call.
+
+If the locals are not available, returns NIL.
+
+See CALL")
+  
   (function file
    "If possible, returns the file the called function is defined in.
 

--- a/interface.lisp
+++ b/interface.lisp
@@ -101,7 +101,8 @@
    (args :initarg :args :reader args)
    (file :initarg :file :reader file)
    (line :initarg :line :reader line)
-   (form :initarg :form :reader form)))
+   (form :initarg :form :reader form)
+   (locals :initform NIL :initarg :locals :reader locals)))
 
 (defmethod print-object ((call call) stream)
   (print-unreadable-object (call stream :type T)

--- a/package.lisp
+++ b/package.lisp
@@ -31,6 +31,7 @@
    #:pos
    #:call
    #:args
+   #:locals
    #:file
    #:line
    #:form


### PR DESCRIPTION
This adds reliable locals fetching for:
- Allegro.
- Clasp.
- CCL 
And suspicious locals for:
- CLISP.

On all these (except for CLISP which I'm extremely uncertain about in all regards), arguments are part of locals.

I've also tried to do locals on 
- ECL: it gives too little information to make inspecting locals easy.
- and ABCL: where SWANK/SLYNK implementation or `frame-locals` looks too intimidating.