### PR TITLE
Fix TYPE-ERROR when processing frames with "more" values.

### DIFF
--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -60,7 +60,9 @@
        (when (and more-context more-count)
          (list (cons 'sb-debug::more
                      (multiple-value-list
-                      (sb-c:%more-arg-values more-context 0 more-count)))))))))
+                      (sb-c:%more-arg-values (sb-di:debug-var-value more-context frame)
+                                             0
+                                             (sb-di:debug-var-value more-count frame))))))))))
 
 (defun make-call (frame)
   (multiple-value-bind (call args info) (sb-debug::frame-call frame)


### PR DESCRIPTION
I started to get this error on fresh Dissect:

    #<TYPE-ERROR expected-type:
         (MOD 4611686018427387901)
          datum:
          #<SB-DI::COMPILED-DEBUG-VAR NIL 0 {1009C76863}>>

I believe a bug was introduced recently in this commit:

SBCL itself passes raw values instead of debug-value to sb-c:%more-arg-values function: https://github.com/sbcl/sbcl/blob/master/src/code/debug.lisp#L604-L610

Bug was caught and fixed on SBCL 2.3.5.